### PR TITLE
replace effective date with begin and end date

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ codenarcVersion=0.21
 # contrib repository properties
 getContribFiles=yes
 contribRepo=git@github.sig.oregonstate.edu:ecs-data/
-contribCommit=fbfbc776d464ed8765935ab4c1f9a84a0640f432
+contribCommit=09c8712eceeef5e5b14f565d275b27e7aff66638

--- a/src/main/groovy/edu/oregonstate/mist/core/JobObject.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/core/JobObject.groovy
@@ -2,7 +2,8 @@ package edu.oregonstate.mist.core
 
 class JobObject {
     String positionNumber
-    Date effectiveDate
+    Date beginDate
+    Date endDate
     String status
     String description
     Float fte

--- a/src/main/groovy/edu/oregonstate/mist/personsapi/mapper/JobsMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/personsapi/mapper/JobsMapper.groovy
@@ -26,7 +26,8 @@ public class JobsMapper implements ResultSetMapper<JobObject> {
             positionNumber: rs.getString('POSITION_NUMBER'),
             fte: rs.getFloat('FTE'),
             description: rs.getString('DESCRIPTION'),
-            effectiveDate: rs.getDate('EFFECTIVE_DATE'),
+            beginDate: rs.getDate('BEGIN_DATE'),
+            endDate: rs.getDate('END_DATE'),
             status: jobStatusDict[rs.getString('STATUS')]
         )
     }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -203,10 +203,14 @@ definitions:
                     positionNumber:
                       type: string
                       description: Identifies a position
-                    effectiveDate:
+                    beginDate:
                       type: string
                       format: date
-                      description: Effective date of job.
+                      description: Begin date of job.
+                    endDate:
+                      type: string
+                      format: date
+                      description: End date of job.
                     status:
                       type: string
                       description: Job staus


### PR DESCRIPTION
This pull request changes the design of the json schema for this API. Begin and end date for a job is more relevant than the lastest effective date.